### PR TITLE
[Model] add qwen2-audio support in vllm.entrypoints.openai.api_server

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
     VLLM_WORKER_MULTIPROC_METHOD: str = "fork"
     VLLM_ASSETS_CACHE: str = os.path.join(VLLM_CACHE_ROOT, "assets")
     VLLM_IMAGE_FETCH_TIMEOUT: int = 5
+    VLLM_AUDIO_FETCH_TIMEOUT: int = 5
     VLLM_TARGET_DEVICE: str = "cuda"
     MAX_JOBS: Optional[str] = None
     NVCC_THREADS: Optional[str] = None
@@ -298,6 +299,11 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     # Default is 5 seconds
     "VLLM_IMAGE_FETCH_TIMEOUT":
     lambda: int(os.getenv("VLLM_IMAGE_FETCH_TIMEOUT", "5")),
+
+    # Timeout for fetching audio when serving multimodal models
+    # Default is 5 seconds
+    "VLLM_AUDIO_FETCH_TIMEOUT":
+        lambda: int(os.getenv("VLLM_AUDIO_FETCH_TIMEOUT", "5")),
 
     # Path to the XLA persistent cache directory.
     # Only used for XLA devices such as TPUs.

--- a/vllm/model_executor/models/qwen2_audio.py
+++ b/vllm/model_executor/models/qwen2_audio.py
@@ -107,14 +107,22 @@ def get_max_qwen2_audio_audio_tokens(ctx: InputContext) -> int:
 
 def input_processor_for_qwen2_audio(ctx: InputContext, llm_inputs: LLMInputs) -> LLMInputs:
     multi_modal_data = llm_inputs.get("multi_modal_data")
+
+    audios = []
+    for data in multi_modal_data['audio']:
+        data = np.array(data, dtype=np.float32)
+        audios.append(data)
     if multi_modal_data is None or "audio" not in multi_modal_data:
         return llm_inputs
 
-    audios = multi_modal_data['audio']
+    # 更改原先的audio值
+    multi_modal_data['audio'] = audios
+    # audios = multi_modal_data['audio']
     processor = cached_get_processor(ctx.model_config.model)
 
     audio_inputs = processor.feature_extractor(
-        audios, sampling_rate=16000, return_attention_mask=True, padding="max_length")
+        audios, sampling_rate=processor.feature_extractor.sampling_rate, return_attention_mask=True, padding="max_length")
+        # audios, sampling_rate=16000, return_attention_mask=True, padding="max_length")
     if not audios:
         return llm_inputs
 


### PR DESCRIPTION
This PR adds qwen2-audio support in vllm.entrypoints.openai.api_server.

So we can use `python -m vllm.entrypoints.openai.api_server --served-model-name qwen2_audio --model model_path  --host 0.0.0.0 --port xx` to start a qwen2-audio service.
